### PR TITLE
salesforce: revenue and loss grouped by opportunity type query

### DIFF
--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -16,7 +16,7 @@ SELECT
 FROM
   public.salesforce_opportunity
 WHERE
-  date_trunc('quarter', "closedate") = date_trunc('quarter', CURRENT_DATE)
+  DATE_TRUNC('quarter', "closedate") = DATE_TRUNC('quarter', CURRENT_DATE)
   AND stagename = 'Closed Won'
 GROUP BY
   1
@@ -28,7 +28,7 @@ SELECT
 FROM
   public.salesforce_opportunity
 WHERE
-  date_trunc('quarter', "closedate") = date_trunc('quarter', CURRENT_DATE)
+  DATE_TRUNC('quarter', "closedate") = DATE_TRUNC('quarter', CURRENT_DATE)
   AND stagename = 'Closed Won'
 ORDER BY
   amount

--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -1,0 +1,38 @@
+---
+title: Salesforce: All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
+description: This query sums the total amount from opportunities grouped by type. A total is displayed at the bottom
+requirements: Collect the `Opportunities` Resource with the Panoply Salesforce data source.
+usage: This query can be displayed in a pivot form to display the total amount per opportunity type.
+
+modifications: The table in the `FROM` might need to be changed based on Schema and Destination settings in the data source. The Date Range Filter using the `closedate` in the `WHERE` clause can be changed.
+---
+
+# Salesforce: All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
+
+```sql
+SELECT
+    "type",
+    SUM("amount") as "amount"
+FROM
+    public.salesforce_opportunity
+WHERE
+    EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
+  AND stagename = 'Closed Won'
+GROUP BY 1
+UNION ALL
+SELECT
+    'TOTAL AMOUNT:' as "type",
+    SUM("amount") as amount
+FROM
+    public.salesforce_opportunity
+WHERE
+    EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
+  AND stagename = 'Closed Won'
+order by amount
+```
+
+## Query Results Dictionary
+Column | Description
+---|---
+`type`| Opportunity type
+`amount`| Sum of the opportunity amount

--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -3,8 +3,7 @@ title: Salesforce: All revenue and loss for the Quarter-To-Date (QTD) grouped by
 description: This query sums the total amount from opportunities grouped by type. A total is displayed at the bottom
 requirements: Collect the `Opportunities` Resource with the Panoply Salesforce data source.
 usage: This query can be displayed in a pivot form to display the total amount per opportunity type.
-
-modifications: The table in the `FROM` might need to be changed based on Schema and Destination settings in the data source. The Date Range Filter using the `closedate` in the `WHERE` clause can be changed.
+modifications: The table in the `FROM` might need to be changed based on Schema and Destination settings in the data source. The Date Range Filter using the `closedate` in the `WHERE` clause can be changed. Everything below the UNION ALL clause can also be removed if you prefer to not have the total at the bottom.
 ---
 
 # Salesforce: All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
@@ -12,7 +11,8 @@ modifications: The table in the `FROM` might need to be changed based on Schema 
 ```sql
 SELECT
   "type",
-  SUM("amount") as "amount"
+  SUM("amount") AS "amount",
+  count(*) AS "opps"
 FROM
   public.salesforce_opportunity
 WHERE
@@ -22,12 +22,13 @@ GROUP BY
   1
 UNION ALL
 SELECT
-  'TOTAL AMOUNT:' as "type",
-  SUM("amount") as "amount"
+  'Total' AS "type",
+  SUM("amount") AS "amount",
+  count(*) AS "opps"
 FROM
   public.salesforce_opportunity
 WHERE
-  EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
+  date_trunc('quarter', "closedate") = date_trunc('quarter', CURRENT_DATE)
   AND stagename = 'Closed Won'
 ORDER BY
   amount
@@ -38,3 +39,4 @@ Column | Description
 ---|---
 `type`| Opportunity type
 `amount`| Sum of the opportunity amount
+`opps`| Opportunity count

--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -11,24 +11,26 @@ modifications: The table in the `FROM` might need to be changed based on Schema 
 
 ```sql
 SELECT
-    "type",
-    SUM("amount") as "amount"
+  "type",
+  SUM("amount") as "amount"
 FROM
-    public.salesforce_opportunity
+  public.salesforce_opportunity
 WHERE
-    EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
+  EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
   AND stagename = 'Closed Won'
-GROUP BY 1
+GROUP BY
+  1
 UNION ALL
 SELECT
-    'TOTAL AMOUNT:' as "type",
-    SUM("amount") as amount
+  'TOTAL AMOUNT:' as "type",
+  SUM("amount") as "amount"
 FROM
-    public.salesforce_opportunity
+  public.salesforce_opportunity
 WHERE
-    EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
+  EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
   AND stagename = 'Closed Won'
-order by amount
+ORDER BY
+  amount
 ```
 
 ## Query Results Dictionary

--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -6,8 +6,6 @@ usage: This query can be displayed in a pivot form to display the total amount p
 modifications: The table in the `FROM` might need to be changed based on Schema and Destination settings in the data source. The Date Range Filter using the `closedate` in the `WHERE` clause can be changed. Everything below the UNION ALL clause can also be removed if you prefer to not have the total at the bottom.
 ---
 
-All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
-
 ```sql
 SELECT
   "type",
@@ -35,8 +33,8 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
-|Column | Description|
-|---|---|
-|`type`| Opportunity type|
-|`amount`| Sum of the opportunity amount|
-|`opps`| Opportunity count|
+| Column | Description |
+|--- | --- |
+| `type` | Opportunity type |
+| `amount` | Sum of the opportunity amount |
+| `opps` | Opportunity count |

--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -1,12 +1,12 @@
 ---
-title: Salesforce: All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
+title: All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
 description: This query sums the total amount from opportunities grouped by type. A total is displayed at the bottom
 requirements: Collect the `Opportunities` Resource with the Panoply Salesforce data source.
 usage: This query can be displayed in a pivot form to display the total amount per opportunity type.
 modifications: The table in the `FROM` might need to be changed based on Schema and Destination settings in the data source. The Date Range Filter using the `closedate` in the `WHERE` clause can be changed. Everything below the UNION ALL clause can also be removed if you prefer to not have the total at the bottom.
 ---
 
-# Salesforce: All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
+All revenue and loss for the Quarter-To-Date (QTD) grouped by type of opportunity.
 
 ```sql
 SELECT
@@ -35,8 +35,8 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
-Column | Description
----|---
-`type`| Opportunity type
-`amount`| Sum of the opportunity amount
-`opps`| Opportunity count
+|Column | Description|
+|---|---|
+|`type`| Opportunity type|
+|`amount`| Sum of the opportunity amount|
+|`opps`| Opportunity count|

--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -12,11 +12,11 @@ modifications: The table in the `FROM` might need to be changed based on Schema 
 SELECT
   "type",
   SUM("amount") AS "amount",
-  count(*) AS "opps"
+  COUNT(*) AS "opps"
 FROM
   public.salesforce_opportunity
 WHERE
-  EXTRACT(quarter FROM "closedate") = EXTRACT(quarter FROM CURRENT_DATE)
+  date_trunc('quarter', "closedate") = date_trunc('quarter', CURRENT_DATE)
   AND stagename = 'Closed Won'
 GROUP BY
   1
@@ -24,7 +24,7 @@ UNION ALL
 SELECT
   'Total' AS "type",
   SUM("amount") AS "amount",
-  count(*) AS "opps"
+  COUNT(*) AS "opps"
 FROM
   public.salesforce_opportunity
 WHERE


### PR DESCRIPTION
This query sums the total amount from opportunities grouped by type. A total is displayed at the bottom