### PR TITLE
Add line breaks between headings and tables

### DIFF
--- a/facebook-ads/queries/last_7_vs_previous_7.md
+++ b/facebook-ads/queries/last_7_vs_previous_7.md
@@ -29,6 +29,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `campaign_name`| Facebook Ads campaign name |

--- a/facebook-ads/queries/monthly_breakdown.md
+++ b/facebook-ads/queries/monthly_breakdown.md
@@ -23,6 +23,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `year_month`| Year and month extracted from the date_start column. Values are in date format with the first day of each month to represent that given month. |

--- a/google-adwords/queries/monthly_breakdown.md
+++ b/google-adwords/queries/monthly_breakdown.md
@@ -24,6 +24,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `year_month`| Year and month extracted from the day column. Values are in date format with the first day of each month to represent that given month. |

--- a/google-analytics/queries/last_7_vs_previous_7.md
+++ b/google-analytics/queries/last_7_vs_previous_7.md
@@ -32,6 +32,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `day_of_week`| Day of the week extracted from datehour |

--- a/google-analytics/queries/medium_breakdown.md
+++ b/google-analytics/queries/medium_breakdown.md
@@ -22,6 +22,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `medium`| The type of referral |

--- a/hubspot/queries/contact-to-mql.md
+++ b/hubspot/queries/contact-to-mql.md
@@ -43,6 +43,7 @@ ORDER BY bins_days_diff
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `bins_days_diff`| Bin indicating the elapsed between contact creation and MQL conversion date. |

--- a/hubspot/queries/form-submissions-analysis.md
+++ b/hubspot/queries/form-submissions-analysis.md
@@ -37,6 +37,7 @@ GROUP BY 1,2,3,4,5;
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `form_id`| Hubspot's internal canonical form identifier, sometimes referred to as the `guid` |

--- a/salesforce/queries/new_opps_summary.md
+++ b/salesforce/queries/new_opps_summary.md
@@ -33,6 +33,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `opp_owner`| Opportunity Owner (Sales Rep) |

--- a/salesforce/queries/revenue_and_loss_by_opportunity_type.md
+++ b/salesforce/queries/revenue_and_loss_by_opportunity_type.md
@@ -33,6 +33,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 |--- | --- |
 | `type` | Opportunity type |

--- a/salesforce/queries/sales_rep_conversion_rate_qtd.md
+++ b/salesforce/queries/sales_rep_conversion_rate_qtd.md
@@ -51,6 +51,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `sales_rep`| Opportunity Owner (Sales Rep) |

--- a/salesforce/queries/sales_rep_ranked_by_revenue.md
+++ b/salesforce/queries/sales_rep_ranked_by_revenue.md
@@ -35,6 +35,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `sales_rep`| Opportunity Owner (Sales Rep) |

--- a/salesforce/views/account_to_email.md
+++ b/salesforce/views/account_to_email.md
@@ -31,6 +31,7 @@ FROM
 ```
 
 ## View Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `email`| Opportunity Email |
@@ -38,4 +39,5 @@ FROM
 | `account_name`| Account Name |
 
 ## Example: New Opportunities Summary
+
 [See Query Details Here](https://github.com/panoplyio/sql-library/blob/master/salesforce/queries/new_opps_summary.md)

--- a/shopify/queries/customer_order_annual_overview.md
+++ b/shopify/queries/customer_order_annual_overview.md
@@ -46,6 +46,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `customer`| Customer's Full Name |

--- a/shopify/queries/order_count_by_processing_method.md
+++ b/shopify/queries/order_count_by_processing_method.md
@@ -28,6 +28,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `processing_method`| Processing methods used by the orders |

--- a/zendesk/queries/ticket_count_per_status_by_paying_customer.md
+++ b/zendesk/queries/ticket_count_per_status_by_paying_customer.md
@@ -60,6 +60,7 @@ ORDER BY
 ```
 
 ## Query Results Dictionary
+
 | Column | Description |
 | --- | --- |
 | `name`| Name of Zendesk User |


### PR DESCRIPTION
## Description
This PR adds line breaks between headings and tables so that they display normally when output by Jekyll. For some reason github flavored markdown is fine with it but Jekyll isnt & wont recognize the table if it occurs immediately after a heading.

Before:
<img width="1282" alt="Screen Shot 2020-12-03 at 10 33 36 PM" src="https://user-images.githubusercontent.com/13478611/101024689-cf693d00-35b7-11eb-8e96-aa231ed67756.png">

After:
<img width="814" alt="Screen Shot 2020-12-03 at 10 33 20 PM" src="https://user-images.githubusercontent.com/13478611/101024702-d2642d80-35b7-11eb-94b2-1fc5fb3633c2.png">
